### PR TITLE
Keep original port number in bcexporter & loki config

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,6 @@ def update_prometheus_config():
 
 def update_loki():
     template_dict = get_template('templates/loki-config.yml')
-    template_dict["server"]["http_listen_port"] = settings["server"]["ports"]["loki"]
     generate_config(template_dict, 'server/loki/loki-config.yml')
 
 

--- a/setup.py
+++ b/setup.py
@@ -122,9 +122,7 @@ def update_promtail():
 
 
 def update_bcexporter():
-    blockchain_exporter_port = settings["clients"]["ports"]["blockchain_exporter"]
     template_dict = get_template('templates/clients/config.yml')
-    template_dict["exporter_port"] = blockchain_exporter_port
     generate_config(template_dict, 'clients/bcexporter/config/config.yml')
 
 


### PR DESCRIPTION
## Issue ticket number and link

NONE

## Description

There is no need to override the port number in the blockchain exporter config file. I am testing with custom ports and realized this with trial and error. As soon as I reverted the port number to the default one, which is the one that the process within the container uses, it started working fine and showing the metrics in the dashboard.

## Type of change

Please delete option that is not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)