### PR TITLE
Add path.rootfs arg to cli arg list

### DIFF
--- a/templates/clients/docker-compose.yml
+++ b/templates/clients/docker-compose.yml
@@ -41,6 +41,7 @@ services:
     command:
       - '--path.procfs=/host/proc'
       - '--path.sysfs=/host/sys'
+      - '--path.rootfs=/rootfs'
       - --collector.filesystem.ignored-mount-points
       - "^/(sys|proc|dev|host|etc|rootfs/var/lib/docker/containers|rootfs/var/lib/docker/overlay2|rootfs/run/docker/netns|rootfs/var/lib/docker/aufs)($$|/)"
     ports:


### PR DESCRIPTION
## Issue ticket number and link

None

## Description

Looking at the 'Machine metrics' I realized that it wasn't getting all the partitions in my system when I looked at the 'Disk space usage' metric. It was just getting `/` and `/home`.

Not being an expert, I decided to google and also went into trial-error mode. I found https://grafana.com/docs/grafana-cloud/quickstart/docker-compose-linux/ and noticed that in the config used for the tool, the `--path.rootfs=/rootfs` CLI argument is missing. So I added and then it started working. Note that in the screenshot below, you can see the transition before adding the CLI arguemtn and then after adding it. The next chunk in the graph shows more colors.

![image](https://user-images.githubusercontent.com/105888566/200187665-76ad5b0f-1bdc-407b-b3b4-c1a7e936798d.png)

If for some reason the intention was to not show all of the partitions in the system, feel free to drop this PR.

## Type of change

Please delete option that is not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
