### PR TITLE
Incorrect parameter type being specified to super constructor of AvaxConnector

### DIFF
--- a/clients/bcexporter/connectors/AvaxConnector.py
+++ b/clients/bcexporter/connectors/AvaxConnector.py
@@ -4,6 +4,7 @@ import urllib.parse
 
 import aiohttp
 
+from connectors.ChainUrl import ChainUrl
 from connectors.EthConnector import EthConnector
 from data.AvaxChainID import AvaxChainID
 from data.ChainSyncStatus import ChainSyncStatus
@@ -19,9 +20,8 @@ class AvaxConnector(EthConnector):
     """
 
     def __init__(self, chain_url_obj, destination, id, chain, request_kwargs=None):
-        self.chain_url_obj = chain_url_obj
-        self.fqd = urllib.parse.urljoin(self.chain_url_obj.get_endpoint(), f"/ext/bc/{chain}/rpc")
-        super().__init__(self.fqd, destination, id, request_kwargs)
+        self.chain_url_obj = ChainUrl(urllib.parse.urljoin(chain_url_obj.get_endpoint(), f"/ext/bc/{chain}/rpc"))
+        super().__init__(self.chain_url_obj, destination, id, request_kwargs)
         self.chain = chain
         self._set_labels()
 


### PR DESCRIPTION
## Issue ticket number and link

None

## Description

EthConnector expects a `ChainUrl` object, but a string (url) is being specified. I updated the code so that it passes down the url wrapped in a ChainUrl object.

The other way to go would have been to construct the ChainUrl object with the correct url right at `connector_utils.create_connectors()`, but i did it this way since it produces the smallest change set.

## Type of change

Please delete option that is not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)