### PR TITLE
Poktblade/pokt connector

### DIFF
--- a/clients/bcexporter/connectors/EthConnector.py
+++ b/clients/bcexporter/connectors/EthConnector.py
@@ -32,7 +32,7 @@ class EthConnector(Web3Connector):
                 asyncio.ensure_future(self.get_current_block())
             ]
             curr_height, *_ = await asyncio.gather(*tasks)
-            sync_dict["status"] = ChainSyncStatus.SYNCaED
+            sync_dict["status"] = ChainSyncStatus.SYNCED
             sync_dict["current_block"] = curr_height
             sync_dict["latest_block"] = curr_height
         else:

--- a/clients/bcexporter/connectors/TendermintConnector.py
+++ b/clients/bcexporter/connectors/TendermintConnector.py
@@ -7,6 +7,7 @@ import aiohttp
 
 from appmetrics.AppMetrics import AppMetrics
 from connectors.ChainUrl import ChainUrl
+from connectors.Web3Connector import Web3Connector
 from data.ChainSyncStatus import ChainSyncStatus
 
 

--- a/clients/bcexporter/connectors/TendermintConnector.py
+++ b/clients/bcexporter/connectors/TendermintConnector.py
@@ -23,7 +23,7 @@ class TendermintConnector(Web3Connector):
         # Returns dict if currently syncing, otherwise returns False
         async with aiohttp.ClientSession() as async_session:
             endpoint = urllib.parse.urljoin(self.chain_url_obj.get_endpoint(), '/status')
-            response = await async_session.post(
+            response = await async_session.get(
                 url=endpoint,
                 headers={"content-type": "application/json"}
             )

--- a/clients/bcexporter/connectors/TendermintConnector.py
+++ b/clients/bcexporter/connectors/TendermintConnector.py
@@ -23,10 +23,7 @@ class TendermintConnector(Web3Connector):
         # Returns dict if currently syncing, otherwise returns False
         async with aiohttp.ClientSession() as async_session:
             endpoint = urllib.parse.urljoin(self.chain_url_obj.get_endpoint(), '/status')
-            response = await async_session.get(
-                url=endpoint,
-                headers={"content-type": "application/json"}
-            )
+            response = await async_session.get(url=endpoint)
             json_object = json.loads((await response.content.read()).decode("utf8"))
             sync_info = json_object["result"]["sync_info"]
             sync_dict = {

--- a/clients/bcexporter/connectors/connector_utils.py
+++ b/clients/bcexporter/connectors/connector_utils.py
@@ -17,7 +17,7 @@ def create_connectors(appmetrics: AppMetrics, chains) -> list:
         if chain["id"] == PoktChainID.POKT:
             connectors.append(TendermintConnector(chain_url_obj=chain_url_obj, destination=appmetrics, id=chain["id"]))
 
-        if chain["id"] == PoktChainID.SWIMMER:
+        elif chain["id"] == PoktChainID.SWIMMER:
             connectors.append(AvaxConnector(chain_url_obj=chain_url_obj, destination=appmetrics, id=chain["id"],
                                             chain=AvaxChainID.SWIMMER))
 

--- a/clients/bcexporter/connectors/connector_utils.py
+++ b/clients/bcexporter/connectors/connector_utils.py
@@ -2,11 +2,10 @@ from appmetrics.AppMetrics import AppMetrics
 from connectors.AvaxConnector import AvaxConnector
 from connectors.ChainUrl import ChainUrl
 from connectors.EthConnector import EthConnector
+from connectors.TendermintConnector import TendermintConnector
 from data.AvaxChainID import AvaxChainID
 from data.PoktChainID import PoktChainID
 from config.Config import Config
-
-from clients.bcexporter.connectors.TendermintConnector import TendermintConnector
 
 
 def create_connectors(appmetrics: AppMetrics, chains) -> list:

--- a/clients/bcexporter/connectors/connector_utils.py
+++ b/clients/bcexporter/connectors/connector_utils.py
@@ -6,6 +6,7 @@ from data.AvaxChainID import AvaxChainID
 from data.PoktChainID import PoktChainID
 from config.Config import Config
 
+from clients.bcexporter.connectors.TendermintConnector import TendermintConnector
 
 
 def create_connectors(appmetrics: AppMetrics, chains) -> list:
@@ -13,6 +14,10 @@ def create_connectors(appmetrics: AppMetrics, chains) -> list:
     alias = Config().alias
     for chain in chains:
         chain_url_obj = ChainUrl(chain["url"], alias)
+
+        if chain["id"] == PoktChainID.POKT:
+            connectors.append(TendermintConnector(chain_url_obj=chain_url_obj, destination=appmetrics, id=chain["id"]))
+
         if chain["id"] == PoktChainID.SWIMMER:
             connectors.append(AvaxConnector(chain_url_obj=chain_url_obj, destination=appmetrics, id=chain["id"],
                                             chain=AvaxChainID.SWIMMER))

--- a/clients/bcexporter/data/PoktChainID.py
+++ b/clients/bcexporter/data/PoktChainID.py
@@ -2,6 +2,7 @@ from enum import Enum
 
 
 class PoktChainID(str, Enum):
+    POKT = "0001"
     DFK = "03DF"
     SWIMMER = "03CB"
     AVAX = "0003"


### PR DESCRIPTION
## Issue ticket number and link

No clickup ticket, as this is a public task.

## Description

Adds a Tendermint connector so that pokt nodes height can be monitored by using the tendermint status endpoint

- Pokt does not have a way to check for peers current height, so we should report current block height as latest height. 

## Type of change

Please delete option that is not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Related PRs

List related PRs below

| branch   | PR       |
| -------- | -------- |
| other_pr | [link]() |
