### PR TITLE
Make host networking only work on bcexporter

### DIFF
--- a/templates/settings.yml
+++ b/templates/settings.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 3
 
 clients:
   node_exporter:
@@ -11,10 +11,14 @@ clients:
     loki_port: 3100
     log_root_path: ./log
   blockchain_exporter:
-    host_networking_enabled: True
+    host_networking:
+      enabled: True
+      internal_port: 9877
     port: 9877
-    alias_enabled: True
-    alias_name: LOCALHOST
+    alias:
+      enabled: True
+      name: LOCALHOST
+    polling_interval_seconds: 5
 
 server:
   loki:


### PR DESCRIPTION
## Issue ticket number and link

https://app.clickup.com/t/4545bvp

## Description

Reformat/add extra yaml key for bcexporter host networking internal port 
Add conditional so host networking only applies to bcexporter
Added error handling for when there is no overrides for chain alerts

## Type of change

Please delete option that is not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
