### PR TITLE
Update code that is accessing an outdated host networking setting

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -127,7 +127,7 @@ def update_alerting_contactpoint():
 def update_docker_service_network_ports(stack: str, service_name: str, template_dict: dict):
     updated = False
     try:
-        if settings[stack][service_name]["host_networking_enabled"] and service_name == 'blockchain_exporter':
+        if settings[stack][service_name]["host_networking"]["enabled"] and service_name == 'blockchain_exporter':
             updated = True
             template_dict["services"][service_name]["network_mode"] = "host"
             del template_dict["services"][service_name]['networks']


### PR DESCRIPTION
## Issue ticket number and link

None

## Description

It seems that the structure of the settings to enable "host networking" for the blockchain exporter changed a bit but a part of the `setup.py` code was not updated properly. I am updating it as part of this PR.

## Type of change

Please delete option that is not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
